### PR TITLE
OPM-3560 - Fix consistent rate limits on CloudkitJS

### DIFF
--- a/AgileCloudKit/AgileCloudKit/CKMediator.m
+++ b/AgileCloudKit/AgileCloudKit/CKMediator.m
@@ -51,6 +51,7 @@ static CKMediator *_mediator;
         // shared operation queue for all cloudkit operations
         _queue = [[NSOperationQueue alloc] init];
         _queue.suspended = YES;
+		_queue.maxConcurrentOperationCount = 1;
 
         _urlQueue = [[NSOperationQueue alloc] init];
 


### PR DESCRIPTION
- Previously the way the cloudkit syncer would work would be to try to upload everything at once with no limits on the queue. This change adds that.
