### PR TITLE
Revert "OPM-3560 - Fix consistent rate limits on CloudkitJS"

### DIFF
--- a/AgileCloudKit/AgileCloudKit/CKMediator.m
+++ b/AgileCloudKit/AgileCloudKit/CKMediator.m
@@ -50,7 +50,6 @@ static CKMediator *_mediator;
         // shared operation queue for all cloudkit operations
         _queue = [[NSOperationQueue alloc] init];
         _queue.suspended = YES;
-		_queue.maxConcurrentOperationCount = 1;
 
         _urlQueue = [[NSOperationQueue alloc] init];
 


### PR DESCRIPTION
This reverts commit a12ce53d6f9ac73d19905f73d81f11155d699e73.

The commit ended up making CloudKit effectively non-functional. Need to figure out a better way of doing this...but for now we'll just put it back like it was.
