### PR TITLE
Always update if savePolicy is CKRecordSaveChangedKeys

### DIFF
--- a/AgileCloudKit/AgileCloudKit/CKModifyRecordsOperation.m
+++ b/AgileCloudKit/AgileCloudKit/CKModifyRecordsOperation.m
@@ -72,7 +72,7 @@
 
             NSDictionary* recordDic = [obj asAgileDictionary];
             NSString* opType = recordDic[@"recordChangeTag"] ? @"update" : @"create";
-            if(self.savePolicy == CKRecordSaveAllKeys){
+            if(self.savePolicy == CKRecordSaveAllKeys || self.savePolicy == CKRecordSaveChangedKeys) {
                 opType = @"forceUpdate";
             }
             return @{ @"operationType" : opType,


### PR DESCRIPTION
If the save policy is explicitly set to saveChangedKeys or saveAllKeys, then it's likely we want to update the record.

operationType in CloudKit Web Services doesn't have a directly correlation to native CloudKit so we have to infer meaning from the savePolicy. We revisit this in the future to be more comprehensive.
