### PR TITLE
Handle UNKNOWN_LIST fields

### DIFF
--- a/AgileCloudKit/AgileCloudKit/CKRecord.m
+++ b/AgileCloudKit/AgileCloudKit/CKRecord.m
@@ -117,6 +117,10 @@
 		}];
 		return refs;
 	}
+	else if ([type isEqualToString:@"UNKNOWN_LIST"]) {
+		// The server appears to return UNKNOWN_LIST for empty STRING_LISTS (and possibly others)
+		return [NSArray array];
+	}
 	else {
 		@throw [NSException exceptionWithName:CKErrorDomain reason:[NSString stringWithFormat:@"Unknown field type: %@", type] userInfo:dictionary];
 	}


### PR DESCRIPTION
The server appears to report empty STRING_LISTs (and probably other lists) as UNKNOWN_LIST (at least it does for me!). In that case, return an empty array.